### PR TITLE
Feat/contributors section

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,7 +4,7 @@ const nextConfig: NextConfig = {
   /* config options here */
   reactStrictMode: true,
   images: {
-    domains: ['images.unsplash.com', 'assets.aceternity.com', 'pbs.twimg.com', 'drive.google.com', 'userpic.codeforces.org', 'cdn.jsdelivr.net', 'api.microlink.io'],
+    domains: ['images.unsplash.com', 'assets.aceternity.com', 'pbs.twimg.com', 'drive.google.com', 'userpic.codeforces.org', 'cdn.jsdelivr.net', 'api.microlink.io', 'api.github.com', 'avatars.githubusercontent.com'],
   },
 };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import MainNavbar from '@/components/shared/main-navbar';
 import { CursorWrapper } from "@/components/home/ui/cursor-wrapper";
 import Footer from "../components/shared/footer";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import Contributors from "@/components/home/sections/contributors";
 
 const navLinks = [
   { key: "home", label: "Home", href: "#home" },
@@ -26,6 +27,7 @@ export default function HomePage() {
           <Hero />
           <AboutUs />
           <Members />
+          <Contributors />
           <Footer />
         </CursorWrapper>
       </QueryClientProvider>

--- a/src/components/home/sections/contributors.tsx
+++ b/src/components/home/sections/contributors.tsx
@@ -1,51 +1,48 @@
 "use client";
 
-import { useEffect, useState } from 'react';
-import { Contributor } from '@/models/contributor.model';
-import { getContributors } from '@/controllers/contributor.controller';
-import Image from 'next/image';
+import { useEffect, useState } from "react";
+import { Contributor } from "@/models/contributor.model";
+import { getContributors } from "@/controllers/contributor.controller";
+import Image from "next/image";
 
 export default function Contributors() {
+  const [contributors, setContributors] = useState<Contributor[]>([]);
 
-    const [contributors, setContributors] = useState<Contributor[]>([]);
+  useEffect(() => {
+    const fetchContributors = async () => {
+      const data = await getContributors();
+      setContributors(data);
+    };
 
-    useEffect(() => {
-        const fetchContributors = async () => {
-            const data = await getContributors();
-            setContributors(data);
-        };
-
-        fetchContributors();
-    }, []);
+    fetchContributors();
+  }, []);
 
   return (
     <div
-            id="contributors"
-            className="space-y-8 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12"
-        >
-            <div className="text-center space-x-4 mb-10">
-                <h4 className="inline dark:text-white">Contribuyen con este proyecto</h4>
-                <span className='dark:text-white font-sans text-semibold bg-gray-400 rounded px-3 py-1'>{contributors.length}</span>
-            </div>
-            <div className="flex justify-center items-center flex-wrap gap-8">
-                {
-                  contributors?.map((contributor) => (
-                    <a 
-                      key={contributor._id}
-                      href={contributor.github}
-                    >
-                      <Image
-                        src={contributor.image}
-                        alt={`Avatar de ${contributor.name}`}
-                        width={48}
-                        height={48}
-                        className='rounded-full border-1 border-black/20 dark:border-white/20'
-                      />
-                    </a>
-                      
-                  ) )
-                }
-            </div>
-        </div>
-  )
+      id="contributors"
+      className="space-y-8 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12"
+    >
+      <div className="text-center space-x-4 mb-10">
+        <h3 className="inline dark:text-white">
+          Contribuyen con este proyecto
+        </h3>
+        <span className="dark:text-white font-sans text-semibold bg-gray-400 rounded px-3 py-1">
+          {contributors.length}
+        </span>
+      </div>
+      <div className="flex justify-center items-center flex-wrap gap-8">
+        {contributors?.map((contributor) => (
+          <a key={contributor._id} href={contributor.github}>
+            <Image
+              src={contributor.image}
+              alt={`Avatar de ${contributor.name}`}
+              width={58}
+              height={58}
+              className="rounded-full border-1 border-black/20 dark:border-white/20"
+            />
+          </a>
+        ))}
+      </div>
+    </div>
+  );
 }

--- a/src/components/home/sections/contributors.tsx
+++ b/src/components/home/sections/contributors.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import { Contributor } from '@/models/contributor.model';
+import { getContributors } from '@/controllers/contributor.controller';
+import Image from 'next/image';
+
+export default function Contributors() {
+
+    const [contributors, setContributors] = useState<Contributor[]>([]);
+
+    useEffect(() => {
+        const fetchContributors = async () => {
+            const data = await getContributors();
+            setContributors(data);
+        };
+
+        fetchContributors();
+    }, []);
+
+  return (
+    <div
+            id="contributors"
+            className="space-y-8 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12"
+        >
+            <div className="text-center space-x-4 mb-10">
+                <h4 className="inline dark:text-white">Contribuyen con este proyecto</h4>
+                <span className='dark:text-white font-sans text-semibold bg-gray-400 rounded px-3 py-1'>{contributors.length}</span>
+            </div>
+            <div className="flex justify-center items-center flex-wrap gap-8">
+                {
+                  contributors?.map((contributor) => (
+                    <a 
+                      key={contributor._id}
+                      href={contributor.github}
+                    >
+                      <Image
+                        src={contributor.image}
+                        alt={`Avatar de ${contributor.name}`}
+                        width={48}
+                        height={48}
+                        className='rounded-full border-1 border-black/20 dark:border-white/20'
+                      />
+                    </a>
+                      
+                  ) )
+                }
+            </div>
+        </div>
+  )
+}

--- a/src/controllers/contributor.controller.ts
+++ b/src/controllers/contributor.controller.ts
@@ -1,0 +1,45 @@
+import { Contributor, GitHubContributor } from "@/models/contributor.model";
+
+const repositories = [
+    { owner: "CapituloJaverianoACM", repo: "ACM-Web-Page-UI" },
+    { owner: "CapituloJaverianoACM", repo: "ACM-cli" },
+    { owner: "CapituloJaverianoACM", repo: "ACM-api" }
+];
+
+function mapRepositoriesToUrls(repos: { owner: string; repo: string }[]): string[] {
+    return repos.map(repo => `https://api.github.com/repos/${repo.owner}/${repo.repo}/contributors`);
+}
+
+async function fetchAndTransformContributors(apiUrl: string): Promise<Contributor[]> {
+    const res = await fetch(apiUrl);
+    
+    if (!res.ok) {
+        console.error(`Error al obtener contribuyentes de ${apiUrl}`);
+        return []; 
+    }
+
+    const githubContributors: GitHubContributor[] = await res.json();
+    return githubContributors.map((contributor) => ({
+        _id: contributor.id,
+        name: contributor.login,
+        image: contributor.avatar_url,
+        github: contributor.html_url,
+    }));
+}
+
+export async function getContributors(): Promise<Contributor[]> {
+    const reposUrls = mapRepositoriesToUrls(repositories);
+    
+    const promises = reposUrls.map(url => fetchAndTransformContributors(url));
+    const allContributorsArrays = await Promise.all(promises);
+    
+    const uniqueContributorsMap = new Map<number, Contributor>();
+    
+    allContributorsArrays.flat().forEach(contributor => {
+        if (!uniqueContributorsMap.has(contributor._id)) {
+            uniqueContributorsMap.set(contributor._id, contributor);
+        }
+    });
+    
+    return Array.from(uniqueContributorsMap.values());
+}

--- a/src/controllers/contributor.controller.ts
+++ b/src/controllers/contributor.controller.ts
@@ -1,45 +1,52 @@
 import { Contributor, GitHubContributor } from "@/models/contributor.model";
 
 const repositories = [
-    { owner: "CapituloJaverianoACM", repo: "ACM-Web-Page-UI" },
-    { owner: "CapituloJaverianoACM", repo: "ACM-cli" },
-    { owner: "CapituloJaverianoACM", repo: "ACM-api" }
+  { owner: "CapituloJaverianoACM", repo: "ACM-Web-Page-UI" },
+  { owner: "CapituloJaverianoACM", repo: "ACM-cli" },
+  { owner: "CapituloJaverianoACM", repo: "ACM-api" },
 ];
 
-function mapRepositoriesToUrls(repos: { owner: string; repo: string }[]): string[] {
-    return repos.map(repo => `https://api.github.com/repos/${repo.owner}/${repo.repo}/contributors`);
+function mapRepositoriesToUrls(
+  repos: { owner: string; repo: string }[],
+): string[] {
+  return repos.map(
+    (repo) =>
+      `https://api.github.com/repos/${repo.owner}/${repo.repo}/contributors`,
+  );
 }
 
-async function fetchAndTransformContributors(apiUrl: string): Promise<Contributor[]> {
-    const res = await fetch(apiUrl);
-    
-    if (!res.ok) {
-        console.error(`Error al obtener contribuyentes de ${apiUrl}`);
-        return []; 
-    }
+async function fetchAndTransformContributors(
+  apiUrl: string,
+): Promise<Contributor[]> {
+  const res = await fetch(apiUrl);
 
-    const githubContributors: GitHubContributor[] = await res.json();
-    return githubContributors.map((contributor) => ({
-        _id: contributor.id,
-        name: contributor.login,
-        image: contributor.avatar_url,
-        github: contributor.html_url,
-    }));
+  if (!res.ok) {
+    console.error(`Error al obtener contribuyentes de ${apiUrl}`);
+    return [];
+  }
+
+  const githubContributors: GitHubContributor[] = await res.json();
+  return githubContributors.map((contributor) => ({
+    _id: contributor.id,
+    name: contributor.login,
+    image: contributor.avatar_url,
+    github: contributor.html_url,
+  }));
 }
 
 export async function getContributors(): Promise<Contributor[]> {
-    const reposUrls = mapRepositoriesToUrls(repositories);
-    
-    const promises = reposUrls.map(url => fetchAndTransformContributors(url));
-    const allContributorsArrays = await Promise.all(promises);
-    
-    const uniqueContributorsMap = new Map<number, Contributor>();
-    
-    allContributorsArrays.flat().forEach(contributor => {
-        if (!uniqueContributorsMap.has(contributor._id)) {
-            uniqueContributorsMap.set(contributor._id, contributor);
-        }
-    });
-    
-    return Array.from(uniqueContributorsMap.values());
+  const reposUrls = mapRepositoriesToUrls(repositories);
+
+  const promises = reposUrls.map((url) => fetchAndTransformContributors(url));
+  const allContributorsArrays = await Promise.all(promises);
+
+  const uniqueContributorsMap = new Map<number, Contributor>();
+
+  allContributorsArrays.flat().forEach((contributor) => {
+    if (!uniqueContributorsMap.has(contributor._id)) {
+      uniqueContributorsMap.set(contributor._id, contributor);
+    }
+  });
+
+  return Array.from(uniqueContributorsMap.values());
 }

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,6 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.SUPABASE_URL!;
-const supabaseKey = process.env.SUPABASE_ANON_KEY!;
+const supabaseUrl = process.env.SUPABASE_URL || "";
+const supabaseKey = process.env.SUPABASE_ANON_KEY || "";
 
 export const supabase = createClient(supabaseUrl, supabaseKey);

--- a/src/models/contributor.model.ts
+++ b/src/models/contributor.model.ts
@@ -1,0 +1,13 @@
+export interface GitHubContributor {
+    id: number;
+    login: string;
+    avatar_url: string;
+    html_url: string;
+}
+
+export interface Contributor {
+    _id: number;
+    name: string;
+    image: string;
+    github: string;
+}


### PR DESCRIPTION
Creación de Sección "Contributors" en la página principal del sitio.

[AGREGADO] contributor.model.ts
En este archivo van a encontrar dos modelos: 1) el de usuario por defecto de GitHub y 2) el usuario que utiliza el formato que lleva el resto de los modelos. La idea con esto es poder transformar los objetos apenas traídos de GitHub para luego manejar únicamente el modelo estándar del resto de la aplicación y evitar futuro errores.

[AGREGADO] contributor.controller.ts
Este archivo consta de tres funciones:
1) Una función que mapea un array de repositorios. Ustedes mencionaron que existe la posibilidad de agregar más repositorios, por lo que esta me pareció la forma más sencilla de hacerlo escalable y mantenible. Si van a utilizar una fuente que no sea GitHub, tendrían que cambiar esto por URLs completas.
2) Una función asíncrona que se utilizará en el fetch para adaptar el formato de usuario que proviene de GitHub al estándar del resto del sitio web.
3) Una función asíncrona que:
a) llama a la función de mapear los repositorios
b) llama a la API y trae los repositorios de GitHub
c) combina los arrays de los colaboradores
d) elimina los duplicados
e) devuelve un array de colaboradores sin duplicados

[AGREGADO] contributors.tsx
Llamada y mapeo de data. Sólo avatares con sus respectivos links a perfiles de GitHub.
Utilicé estilos de TailwindCSS y del archivo global.css

[MODIFICADO] page.tsx
Aguegué el componente antes del Footer.

[MODIFICADO] next.config.ts
Agregué la API de GitHub a los dominios de imágenes permitidos.


A TENER EN CUENTA:
- Si el tráfico del sitio va a crecer considerablemente, considerar utilizar otra estrategia para el fetch de datos que no vaya a saturar las llamadas a la API de GitHub.