### PR TITLE
Update video resources and enhance roadmap steps

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -273,12 +273,20 @@
         "subtitle": "What is the league? What do I need to participate?"
       },
       "step2": {
+        "title": "Using the USACO IDE to write the solution to a problem",
+        "subtitle": "Where do I write my code?"
+      },
+      "step3": {
         "title": "Submitting your first problem to the Codeforces platform",
         "subtitle": "How do I submit a problem?"
       },
-      "step3": {
+      "step4": {
         "title": "CodeForces Veredict",
         "subtitle": "What're the meanings for each veredict in CodeForces?"
+      },
+      "step5": {
+        "title": "Actions within the chapter page",
+        "subtitle": "What steps should I follow on the page?"
       }
     }
   },

--- a/messages/es.json
+++ b/messages/es.json
@@ -140,6 +140,7 @@
         "topics": "Temas",
         "materials": "Material del Curso"
       },
+
       "topics": {
         "dataStructures": "Estructuras de datos",
         "programmingLogic": "Lógica de programación",
@@ -147,6 +148,7 @@
         "algorithmicThinking": "Pensamiento algorítmico",
         "basicProgramming": "Programación básica"
       },
+
       "items": {
         "python": {
           "title": "Curso De Python",
@@ -271,12 +273,20 @@
         "subtitle": "¿Qué es la liga? ¿Qué necesito para participar?"
       },
       "step2": {
+        "title": "Usando Usaco IDE para escribir la solución a un problema",
+        "subtitle": "¿En donde escribo mi codigo?"
+      },
+      "step3": {
         "title": "Subiendo tu primer problema a la plataforma de Codeforces",
         "subtitle": "¿Cómo envío un problema?"
       },
-      "step3": {
+      "step4": {
         "title": "Respuestas CodeForces",
         "subtitle": "¿Qué significan los veredictos que el juez lanza de mis problemas?"
+      },
+      "step5": {
+        "title": "Acciones dentro de la pagina del capitulo",
+        "subtitle": "¿Que pasos debo seguir dentro de la pagina?"
       }
     }
   },

--- a/src/components/league/sections/roadmap.tsx
+++ b/src/components/league/sections/roadmap.tsx
@@ -18,19 +18,31 @@ export function Roadmap() {
       number: 1,
       title: t("step1.title"),
       subtitle: t("step1.subtitle"),
-      videoSrc: "https://youtu.be/EVUEIHcbZic",
+      videoSrc: "https://youtu.be/_nwVJd0BuEA",
     },
     {
       number: 2,
       title: t("step2.title"),
       subtitle: t("step2.subtitle"),
-      videoSrc: "https://youtu.be/EVUEIHcbZic",
+      videoSrc: "https://youtu.be/YkIaDIJXyX0",
     },
     {
       number: 3,
       title: t("step3.title"),
       subtitle: t("step3.subtitle"),
-      videoSrc: "https://www.youtube.com/watch?v=2iC96v5MZ5o",
+      videoSrc: "https://youtu.be/EVUEIHcbZic",
+    },
+    {
+      number: 4,
+      title: t("step4.title"),
+      subtitle: t("step4.subtitle"),
+      videoSrc: "https://youtu.be/2iC96v5MZ5o",
+    },
+    {
+      number: 5,
+      title: t("step5.title"),
+      subtitle: t("step5.subtitle"),
+      videoSrc: "https://youtu.be/tlKhIj8F1qA",
     },
   ];
 


### PR DESCRIPTION
This pull request updates the League roadmap section by expanding the step-by-step guide, adding new steps and corresponding video resources, and updating translations for both English and Spanish. The main focus is to provide a clearer, more comprehensive onboarding process for users, with improved instructional content and support for multiple languages.

**Roadmap and instructional content improvements:**

* Expanded the roadmap to five steps, introducing new steps for using the USACO IDE, understanding actions within the chapter page, and clarifying the Codeforces verdicts. Each step now has an associated video guide, with updated video links to match the new content. (`src/components/league/sections/roadmap.tsx`)

**Localization and translation updates:**

* Added new step titles and subtitles for steps 2, 4, and 5 in the English roadmap section, ensuring all steps are clearly described. (`messages/en.json`)
* Added equivalent new step titles and subtitles for steps 2, 4, and 5 in the Spanish roadmap section, maintaining consistency across languages. (`messages/es.json`)
* Minor formatting improvements in the Spanish translation file for better readability. (`messages/es.json`)